### PR TITLE
added note to README for building HHVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Restart hhvm
 
 You have to build hhvm with HOTPROFILE support
 
-* Check out my hhvm branch with newrelic-profiling support 
+* Follow the Installation prerequisites for the normal plugin, copying the newrelic agent_sdk library and header files to their necesary location
+* Check out my hhvm branch with newrelic-profiling support
 * Go to your hhvm sources
 
 ```` 


### PR DESCRIPTION
I already made a ticket that I got some errors while building when I noticed it was the missing agent_sdk files (I went straight for the HHVM building instead of just trying the plugin first)
